### PR TITLE
matchアームがブロックでない時にも適切にフックされるよう修正

### DIFF
--- a/hooq-macros/tests/special/skip_detail.expanded.rs
+++ b/hooq-macros/tests/special/skip_detail.expanded.rs
@@ -740,6 +740,19 @@ fn skip_expr() -> Result<(), ()> {
                 })?;
             enresult(())
         }
+        None if enresult(true)
+            .inspect(|_| {
+                {
+                    ::std::io::_print(format_args!("tag: {0}\n", "match"));
+                };
+            })? => {
+            Err(())
+                .inspect(|_| {
+                    {
+                        ::std::io::_print(format_args!("tag: {0}\n", "match"));
+                    };
+                })
+        }
         None => enresult(()),
     }?;
     impl Strct {

--- a/hooq-macros/tests/special/skip_detail.rs
+++ b/hooq-macros/tests/special/skip_detail.rs
@@ -447,6 +447,7 @@ fn skip_expr() -> Result<(), ()> {
             enresult(())?;
             enresult(())
         }
+        None if enresult(true)? => Err(()),
         None => enresult(()),
     }?;
 


### PR DESCRIPTION
## 📌 Overview / 概要

<!-- What does this PR do? -->
<!-- このPRの目的や概要を簡潔に記述してください -->

表題の通り。matchアームの右辺の値がブロックではなく単体の式であった際、本来フックすべき時もフックしない不具合があったので修正

## ⚙ Changes / 変更点

<!--
List the main changes in this PR.
箇条書きで構いません。主要な変更点を書いてください。
-->

<!-- Examples
- Add `Foo` struct to support X
- Fix `Bar` function panic on edge case
- Refactor internal logic in `baz.rs`
-->

- walker/mod.rs
- skip_detail.rs

## 🧪 Tests / テスト

<!--
What tests were added or updated?
How did you confirm it works?
どんなテストを追加・更新しましたか？動作確認はどのように行いましたか？
-->

<!-- Examples
- Added unit tests for `foo::do_something`
- Manually verified with `cargo test`
-->

関連するテストも修正された

## 📚 Related Issues / 関連Issue

<!--
If this PR fixes or is related to any issue, reference it here.
Issueがある場合はここに貼ってください（例: closes #12）
-->

<!-- Examples
closes #12
-->

#109 

## ✅ Checklist

<!--
Check all items that apply.
当てはまる項目にチェックを入れてください（"x" を入力）
-->

- [x] I’ve added or updated tests. (必要なテストを用意しました)
- [x] I’ve updated documentation or comments if needed. (必要に応じてドキュメント/コメントを更新しました)
- [x] I’ve considered backward compatibility (if public API is changed). (公開されているAPIが変化する場合、後方互換性に配慮しました)
